### PR TITLE
Use https download urls

### DIFF
--- a/archivo-black-fonts/archivo-black-fonts.spec
+++ b/archivo-black-fonts/archivo-black-fonts.spec
@@ -9,7 +9,7 @@ Summary: Grotesque sans-serif typeface derived from Chivo. Black style
 Group:   User Interface/X
 License: OFL
 URL:     https://omnibus-type.com/
-Source0: https://omnibus-type.com/download/ArchivoBlack-for-Print.zip
+Source0: https://www.omnibus-type.com/wp-content/uploads/Archivo-Black.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/archivo-black-fonts/archivo-black-fonts.spec
+++ b/archivo-black-fonts/archivo-black-fonts.spec
@@ -8,8 +8,8 @@ Summary: Grotesque sans-serif typeface derived from Chivo. Black style
 
 Group:   User Interface/X
 License: OFL
-URL:     http://omnibus-type.com/
-Source0: http://omnibus-type.com/download/ArchivoBlack-for-Print.zip
+URL:     https://omnibus-type.com/
+Source0: https://omnibus-type.com/download/ArchivoBlack-for-Print.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/archivo-black-fonts/archivo-black-fonts.spec
+++ b/archivo-black-fonts/archivo-black-fonts.spec
@@ -22,7 +22,7 @@ derived from Chivo. Black style.
 
 
 %prep
-%setup -q -n ArchivoBlack-for-Print
+%setup -q -n Archivo-Black
 
 %build
 

--- a/courier-prime-fonts/courier-prime-fonts.spec
+++ b/courier-prime-fonts/courier-prime-fonts.spec
@@ -8,8 +8,8 @@ Summary: A free, improved, classical monospaced typeface
 
 Group:   User Interface/X
 License: OFL
-URL:     http://quoteunquoteapps.com/courierprime/
-Source0: http://quoteunquoteapps.com/downloads/courier-prime.zip
+URL:     https://quoteunquoteapps.com/courierprime/
+Source0: https://quoteunquoteapps.com/downloads/courier-prime.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/libre-baskerville-fonts/libre-baskerville-fonts.spec
+++ b/libre-baskerville-fonts/libre-baskerville-fonts.spec
@@ -7,8 +7,8 @@ Release: 2%{?dist}
 Summary: Libre Baskerville font designed by Pablo Impallari
 Group:   User Interface/X
 License: OFL
-URL:     http://www.impallari.com/
-Source0: http://www.impallari.com/media/uploads/prosources/update-86-source.zip
+URL:     https://www.impallari.com/
+Source0: https://www.impallari.com/media/uploads/prosources/update-86-source.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/libre-baskerville-fonts/libre-baskerville-fonts.spec
+++ b/libre-baskerville-fonts/libre-baskerville-fonts.spec
@@ -8,7 +8,7 @@ Summary: Libre Baskerville font designed by Pablo Impallari
 Group:   User Interface/X
 License: OFL
 URL:     https://www.impallari.com/
-Source0: https://www.impallari.com/media/uploads/prosources/update-86-source.zip
+Source0: https://fonts.google.com/download?family=Libre%20Baskerville
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/signika-fonts/signika-fonts.spec
+++ b/signika-fonts/signika-fonts.spec
@@ -8,8 +8,8 @@ Summary: Sans-serif font with a gentle character
 
 Group:   User Interface/X
 License: OFL
-URL:     http://fontfabric.com/signika-font/
-Source0: http://www.fontfabric.com/downfont/signika.zip
+URL:     https://fontfabric.com/signika-font/
+Source0: https://www.fontfabric.com/downfont/signika.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/ubuntu-fonts/ubuntu-fonts.spec
+++ b/ubuntu-fonts/ubuntu-fonts.spec
@@ -7,8 +7,8 @@ Release: 1%{?dist}
 Summary: Ubuntu font family
 
 License: Ubuntu Font Licence 1.0
-URL:     http://font.ubuntu.com/
-Source0: http://font.ubuntu.com/download/ubuntu-font-family-0.83.zip
+URL:     https://font.ubuntu.com/
+Source0: https://font.ubuntu.com/download/ubuntu-font-family-0.83.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch

--- a/ubuntu-fonts/ubuntu-fonts.spec
+++ b/ubuntu-fonts/ubuntu-fonts.spec
@@ -8,7 +8,7 @@ Summary: Ubuntu font family
 
 License: Ubuntu Font Licence 1.0
 URL:     https://font.ubuntu.com/
-Source0: https://font.ubuntu.com/download/ubuntu-font-family-0.83.zip
+Source0: https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip
 Source1: %{fontname}-fontconfig.conf
 
 BuildArch:     noarch


### PR DESCRIPTION
It seems COPR doesn't support downloading files from http urls anymore. I changed them to use https, and also fixed the download link for the ubuntu font.

Now COPR can build most of these, except the ones hosted on google-fonts that use the shell script.

https://copr.fedorainfracloud.org/coprs/psadauskas/fedora-better-fonts/packages/