### PR TITLE
Fix broken symlink for ubuntu-fonts

### DIFF
--- a/notes
+++ b/notes
@@ -2,6 +2,9 @@ Open Sans is sooo much better than Arimo
 - Open Sans and Noto Sans are pretty much indentical
 - Noto Sans has a bit thicker glyphs and less accents
 
+test
+2323
+
 Lucida Grande:
 Lucida Sans:
 Lucida Sans Unicode:

--- a/ubuntu-fonts/ubuntu-fonts.spec
+++ b/ubuntu-fonts/ubuntu-fonts.spec
@@ -35,7 +35,7 @@ install -m 0755 -d %{buildroot}%{_fontconfig_templatedir} \
 
 install -m 0644 -p %{SOURCE1} \
         %{buildroot}%{_fontconfig_templatedir}/%{fontconf}
-ln -s %{_fontconfig_templatedir}/%{fontconf}.conf \
+ln -s %{_fontconfig_templatedir}/%{fontconf} \
       %{buildroot}%{_fontconfig_confdir}/%{fontconf}
 
 %_font_pkg -f *-%{fontname}.conf *.ttf


### PR DESCRIPTION
Now we have symlink `/etc/fonts/conf.d/61-ubuntu.conf -> /usr/share/fontconfig/conf.avail/61-ubuntu.conf.conf` but it should be the link to `/usr/share/fontconfig/conf.avail/61-ubuntu.conf`