### PR TITLE
Fix broken symlink /etc/fonts/conf.d/61-ubuntu.conf

### DIFF
--- a/ubuntu-fonts/ubuntu-fonts.spec
+++ b/ubuntu-fonts/ubuntu-fonts.spec
@@ -35,7 +35,7 @@ install -m 0755 -d %{buildroot}%{_fontconfig_templatedir} \
 
 install -m 0644 -p %{SOURCE1} \
         %{buildroot}%{_fontconfig_templatedir}/%{fontconf}
-ln -s %{_fontconfig_templatedir}/%{fontconf}.conf \
+ln -s %{_fontconfig_templatedir}/%{fontconf} \
       %{buildroot}%{_fontconfig_confdir}/%{fontconf}
 
 %_font_pkg -f *-%{fontname}.conf *.ttf


### PR DESCRIPTION
Now we have broken symlink `/etc/fonts/conf.d/61-ubuntu.conf` that follows to `/usr/share/fontconfig/conf.avail/61-ubuntu.conf.conf` but it should follow to `/usr/share/fontconfig/conf.avail/61-ubuntu.conf` . This PR fixes this bug.