### PR TITLE
Build Google Fonts using 'make srpm' method on COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,6 @@
+srpm:
+	dnf -y install wget
+	find -type f -executable -exec {} \;
+	cp -r ./* /builddir/build/SOURCES/
+	rpmbuild -bs *.spec
+	cp -r /builddir/build/SRPMS/* \$(outdir)

--- a/libre-baskerville-fonts/get-libre-baskerville.sh
+++ b/libre-baskerville-fonts/get-libre-baskerville.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Get upstream zip and make source tar.gz
+
+ARCHIVE="libre-baskerville-fonts-1.0"
+TMPDIR=$(mktemp -d --tmpdir=/var/tmp getlibrebaskerville-XXXXXXXXXX)
+[ $? != 0 ] && exit 1
+umask 022
+pushd "$TMPDIR"
+
+wget -N -O $ARCHIVE.zip https://fonts.google.com/download?family=Libre%20Baskerville
+unzip $ARCHIVE.zip -d $ARCHIVE
+tar -cvJf "$ARCHIVE.tar.xz" $ARCHIVE
+
+popd
+mv "$TMPDIR/$ARCHIVE.tar.xz" .
+rm -fr "$TMPDIR"

--- a/libre-baskerville-fonts/libre-baskerville-fonts.spec
+++ b/libre-baskerville-fonts/libre-baskerville-fonts.spec
@@ -3,13 +3,14 @@
 
 Name:    %{fontname}-fonts
 Version: 1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Libre Baskerville font designed by Pablo Impallari
 Group:   User Interface/X
 License: OFL
-URL:     https://www.impallari.com/
-Source0: https://www.impallari.com/media/uploads/prosources/update-86-source.zip
+URL:     https://fonts.google.com/specimen/Libre+Baskerville
+Source0: %{name}-%{version}.tar.xz
 Source1: %{fontname}-fontconfig.conf
+Source2: get-libre-baskerville.sh
 
 BuildArch:     noarch
 BuildRequires: fontpackages-devel
@@ -23,8 +24,7 @@ allow it to work well for reading on-screen.
 
 
 %prep
-%setup -q -c
-cp 'Libre Baskerville v%{version}'/{*.ttf,*.txt} .
+%setup -q
 
 %build
 
@@ -40,17 +40,16 @@ install -m 0644 -p %{SOURCE1} \
 ln -s %{_fontconfig_templatedir}/%{fontconf} \
       %{buildroot}%{_fontconfig_confdir}/%{fontconf}
 
-cp OFL.txt LICENSE
-for _file in FONTLOG.txt LICENSE; do
-    chmod 0644 $_file
-    sed -i 's/\r$//' $_file
-done
+mv OFL.txt LICENSE
+sed -i 's/\r$//' LICENSE
 
 %_font_pkg -f %{fontconf} *.ttf
 %license LICENSE
-%doc FONTLOG.txt
 
 %changelog
+* Fri Oct 30 2020 Dawid Zych <dawid.zych@yandex.com> 1.0-3
+- Download font from Google Fonts (@paul)
+
 * Wed Jan 11 2017 Dawid Zych <dawid.zych@yandex.com> 1.0-2
 - Update fontconfig and it's priority.
 


### PR DESCRIPTION
By creating `.copr/Makefile` we can run custom scripts on COPR server.
That way we can download font from Google before building package.

Obsoletes #12 